### PR TITLE
Implement potion interface

### DIFF
--- a/MainActivity.cs
+++ b/MainActivity.cs
@@ -3,12 +3,82 @@ namespace Potionapp_Mobile
     [Activity(Label = "@string/app_name", MainLauncher = true)]
     public class MainActivity : Activity
     {
+        readonly Dictionary<string, Dictionary<string, int>> potionRequirements = new()
+        {
+            { "Healing Potion", new Dictionary<string, int>{{"berry",1},{"herb",1},{"solution",1}} },
+            { "Magic Potion", new Dictionary<string, int>{{"magic",1},{"root",1},{"solution",1}} },
+            { "Stone Skin Potion", new Dictionary<string, int>{{"fungi",1},{"mineral",1},{"solution",1}} },
+            { "Animal Brew", new Dictionary<string, int>{{"animal",1},{"magic",1},{"solution",1}} }
+        };
+
+        Dictionary<string, EditText>? ingredientFields;
+        List<string>? selectedPotions;
+        ArrayAdapter<string>? listAdapter;
+
         protected override void OnCreate(Bundle? savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
 
             // Set our view from the "main" layout resource
             SetContentView(Resource.Layout.activity_main);
+
+            ingredientFields = new Dictionary<string, EditText>
+            {
+                { "animal", FindViewById<EditText>(Resource.Id.animal_amount)! },
+                { "berry", FindViewById<EditText>(Resource.Id.berry_amount)! },
+                { "fungi", FindViewById<EditText>(Resource.Id.fungi_amount)! },
+                { "herb", FindViewById<EditText>(Resource.Id.herb_amount)! },
+                { "magic", FindViewById<EditText>(Resource.Id.magic_amount)! },
+                { "mineral", FindViewById<EditText>(Resource.Id.mineral_amount)! },
+                { "root", FindViewById<EditText>(Resource.Id.root_amount)! },
+                { "solution", FindViewById<EditText>(Resource.Id.solution_amount)! }
+            };
+
+            var potionSpinner = FindViewById<Spinner>(Resource.Id.potion_spinner)!;
+            var potionNames = potionRequirements.Keys.ToList();
+            potionSpinner.Adapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleSpinnerItem, potionNames);
+
+            var addButton = FindViewById<Button>(Resource.Id.add_potion_button)!;
+            var confirmButton = FindViewById<Button>(Resource.Id.confirm_button)!;
+            var listView = FindViewById<ListView>(Resource.Id.selected_potions_list)!;
+
+            selectedPotions = new List<string>();
+            listAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1, selectedPotions);
+            listView.Adapter = listAdapter;
+
+            addButton.Click += (s, e) =>
+            {
+                var selected = potionSpinner.SelectedItem?.ToString();
+                if (!string.IsNullOrEmpty(selected))
+                {
+                    selectedPotions!.Add(selected);
+                    listAdapter!.NotifyDataSetChanged();
+                }
+            };
+
+            confirmButton.Click += (s, e) =>
+            {
+                foreach (var potion in selectedPotions!.ToList())
+                {
+                    if (!potionRequirements.TryGetValue(potion, out var reqs))
+                        continue;
+
+                    foreach (var kvp in reqs)
+                    {
+                        if (ingredientFields!.TryGetValue(kvp.Key, out var field))
+                        {
+                            if (int.TryParse(field.Text, out int val))
+                            {
+                                val = Math.Max(0, val - kvp.Value);
+                                field.Text = val.ToString();
+                            }
+                        }
+                    }
+                }
+
+                selectedPotions.Clear();
+                listAdapter!.NotifyDataSetChanged();
+            };
         }
     }
 }

--- a/Resources/layout/activity_main.xml
+++ b/Resources/layout/activity_main.xml
@@ -1,13 +1,164 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <TextView 
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="@string/app_text"
-    />
-</RelativeLayout>
+        android:padding="16dp">
+
+        <!-- Ingredient amount fields -->
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Animal" />
+            <EditText
+                android:id="@+id/animal_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Berry" />
+            <EditText
+                android:id="@+id/berry_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Fungi" />
+            <EditText
+                android:id="@+id/fungi_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Herb" />
+            <EditText
+                android:id="@+id/herb_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Magic" />
+            <EditText
+                android:id="@+id/magic_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Mineral" />
+            <EditText
+                android:id="@+id/mineral_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Root" />
+            <EditText
+                android:id="@+id/root_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Solution" />
+            <EditText
+                android:id="@+id/solution_amount"
+                android:inputType="number"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <!-- Potion selector and add button -->
+        <Spinner
+            android:id="@+id/potion_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <Button
+            android:id="@+id/add_potion_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Add Potion" />
+
+        <!-- Selected potions list -->
+        <ListView
+            android:id="@+id/selected_potions_list"
+            android:layout_width="match_parent"
+            android:layout_height="200dp" />
+
+        <Button
+            android:id="@+id/confirm_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Confirm" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- extend `activity_main.xml` with ingredient inputs, potion selector, selected potions list, and confirm button
- add UI logic in `MainActivity` to handle potion selection and ingredient deduction

## Testing
- `dotnet build 'Potionapp Mobile.sln' -c Release` *(fails: target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6844d8226edc8329bfdf1fc4698787e8