### PR TITLE
Add recipe and ingredient management

### DIFF
--- a/MainActivity.cs
+++ b/MainActivity.cs
@@ -11,16 +11,32 @@ namespace Potionapp_Mobile
             { "Animal Brew", new Dictionary<string, int>{{"animal",1},{"magic",1},{"solution",1}} }
         };
 
+        readonly Dictionary<string, List<string>> potionSpecialRequirements = new();
+        readonly List<string> specialIngredientsStock = new();
+
         Dictionary<string, EditText>? ingredientFields;
         List<string>? selectedPotions;
         ArrayAdapter<string>? listAdapter;
+        ArrayAdapter<string>? recipesAdapter;
+        ArrayAdapter<string>? specialAdapter;
+        List<string>? recipeNames;
 
         protected override void OnCreate(Bundle? savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
 
-            // Set our view from the "main" layout resource
-            SetContentView(Resource.Layout.activity_main);
+            SetContentView(Resource.Layout.main_tabs);
+
+            var tabHost = FindViewById<TabHost>(Android.Resource.Id.TabHost)!;
+            tabHost.Setup();
+
+            tabHost.AddTab(tabHost.NewTabSpec("potions").SetIndicator("Potions").SetContent(Resource.Id.tab_potions));
+            tabHost.AddTab(tabHost.NewTabSpec("recipes").SetIndicator("Recipes").SetContent(Resource.Id.tab_recipes));
+            tabHost.AddTab(tabHost.NewTabSpec("ingredients").SetIndicator("Ingredients").SetContent(Resource.Id.tab_ingredients));
+
+            LayoutInflater.Inflate(Resource.Layout.activity_main, tabHost.TabContentView.FindViewById(Resource.Id.tab_potions), true);
+            LayoutInflater.Inflate(Resource.Layout.recipes_tab, tabHost.TabContentView.FindViewById(Resource.Id.tab_recipes), true);
+            LayoutInflater.Inflate(Resource.Layout.ingredients_tab, tabHost.TabContentView.FindViewById(Resource.Id.tab_ingredients), true);
 
             ingredientFields = new Dictionary<string, EditText>
             {
@@ -74,10 +90,94 @@ namespace Potionapp_Mobile
                             }
                         }
                     }
+
+                    if (potionSpecialRequirements.TryGetValue(potion, out var specials))
+                    {
+                        foreach (var sp in specials)
+                            specialIngredientsStock.Remove(sp);
+                        specialAdapter?.NotifyDataSetChanged();
+                    }
                 }
 
                 selectedPotions.Clear();
                 listAdapter!.NotifyDataSetChanged();
+            };
+
+            // Recipes tab setup
+            recipeNames = potionRequirements.Keys.ToList();
+            var recipesList = FindViewById<ListView>(Resource.Id.recipes_list)!;
+            recipesAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1, recipeNames);
+            recipesList.Adapter = recipesAdapter;
+            recipesList.ChoiceMode = ChoiceMode.Single;
+
+            var addRecipeBtn = FindViewById<Button>(Resource.Id.add_recipe_button)!;
+            var removeRecipeBtn = FindViewById<Button>(Resource.Id.remove_recipe_button)!;
+
+            addRecipeBtn.Click += (s, e) =>
+            {
+                var name = FindViewById<EditText>(Resource.Id.recipe_name)!.Text;
+                if (string.IsNullOrWhiteSpace(name) || potionRequirements.ContainsKey(name))
+                    return;
+
+                var reqs = new Dictionary<string, int>();
+                foreach (var key in ingredientFields!.Keys)
+                {
+                    var id = Resources.GetIdentifier($"recipe_{key}", "id", PackageName);
+                    var field = FindViewById<EditText>(id)!;
+                    if (int.TryParse(field.Text, out int val) && val > 0)
+                        reqs[key] = val;
+                }
+
+                potionRequirements[name] = reqs;
+                recipeNames!.Add(name);
+
+                var specialsText = FindViewById<EditText>(Resource.Id.recipe_special)!.Text;
+                if (!string.IsNullOrWhiteSpace(specialsText))
+                    potionSpecialRequirements[name] = specialsText.Split(',').Select(s => s.Trim()).Where(s => s.Length > 0).ToList();
+
+                recipesAdapter!.NotifyDataSetChanged();
+                potionSpinner.Adapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleSpinnerItem, potionRequirements.Keys.ToList());
+            };
+
+            removeRecipeBtn.Click += (s, e) =>
+            {
+                if (recipesList.CheckedItemPosition >= 0 && recipesList.CheckedItemPosition < recipeNames!.Count)
+                {
+                    var name = recipeNames[recipesList.CheckedItemPosition];
+                    recipeNames.RemoveAt(recipesList.CheckedItemPosition);
+                    potionRequirements.Remove(name);
+                    potionSpecialRequirements.Remove(name);
+                    recipesAdapter!.NotifyDataSetChanged();
+                    potionSpinner.Adapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleSpinnerItem, potionRequirements.Keys.ToList());
+                }
+            };
+
+            // Special ingredients tab setup
+            var specialList = FindViewById<ListView>(Resource.Id.special_list)!;
+            specialAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1, specialIngredientsStock);
+            specialList.Adapter = specialAdapter;
+            specialList.ChoiceMode = ChoiceMode.Single;
+
+            var addSpecialBtn = FindViewById<Button>(Resource.Id.add_special_button)!;
+            var removeSpecialBtn = FindViewById<Button>(Resource.Id.remove_special_button)!;
+
+            addSpecialBtn.Click += (s, e) =>
+            {
+                var name = FindViewById<EditText>(Resource.Id.special_name)!.Text;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    specialIngredientsStock.Add(name.Trim());
+                    specialAdapter!.NotifyDataSetChanged();
+                }
+            };
+
+            removeSpecialBtn.Click += (s, e) =>
+            {
+                if (specialList.CheckedItemPosition >= 0 && specialList.CheckedItemPosition < specialIngredientsStock.Count)
+                {
+                    specialIngredientsStock.RemoveAt(specialList.CheckedItemPosition);
+                    specialAdapter!.NotifyDataSetChanged();
+                }
             };
         }
     }

--- a/Resources/layout/ingredients_tab.xml
+++ b/Resources/layout/ingredients_tab.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/special_name"
+        android:hint="Special ingredient"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <Button
+        android:id="@+id/add_special_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Add" />
+
+    <ListView
+        android:id="@+id/special_list"
+        android:layout_width="match_parent"
+        android:layout_height="200dp" />
+    <Button
+        android:id="@+id/remove_special_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Remove Selected" />
+</LinearLayout>

--- a/Resources/layout/main_tabs.xml
+++ b/Resources/layout/main_tabs.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TabHost xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/tabhost"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TabWidget
+            android:id="@android:id/tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <FrameLayout
+            android:id="@android:id/tabcontent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <LinearLayout
+                android:id="@+id/tab_potions"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+            <LinearLayout
+                android:id="@+id/tab_recipes"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+            <LinearLayout
+                android:id="@+id/tab_ingredients"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
+    </LinearLayout>
+</TabHost>

--- a/Resources/layout/recipes_tab.xml
+++ b/Resources/layout/recipes_tab.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/recipe_name"
+            android:hint="Recipe Name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <!-- Ingredient fields for recipe -->
+        <EditText
+            android:id="@+id/recipe_animal"
+            android:hint="Animal amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_berry"
+            android:hint="Berry amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_fungi"
+            android:hint="Fungi amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_herb"
+            android:hint="Herb amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_magic"
+            android:hint="Magic amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_mineral"
+            android:hint="Mineral amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_root"
+            android:hint="Root amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/recipe_solution"
+            android:hint="Solution amount"
+            android:inputType="number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/recipe_special"
+            android:hint="Special ingredients (comma separated)"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <Button
+            android:id="@+id/add_recipe_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Add Recipe" />
+
+        <ListView
+            android:id="@+id/recipes_list"
+            android:layout_width="match_parent"
+            android:layout_height="200dp" />
+        <Button
+            android:id="@+id/remove_recipe_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Remove Selected" />
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- switch main screen to a TabHost with tabs
- enable adding/removing recipes and special ingredients
- update brew logic to consume special ingredients

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dd7f35c883299645550efe22e1c9