### PR TITLE
Add drawer navigation and queue list

### DIFF
--- a/MainActivity.cs
+++ b/MainActivity.cs
@@ -2,6 +2,8 @@ using Android.App;
 using Android.OS;
 using Android.Widget;
 using Android.Views;
+using AndroidX.DrawerLayout.Widget;
+using AndroidX.Core.View;
 using System.Collections.Generic;
 using System.Linq;
 namespace Potionapp_Mobile
@@ -75,8 +77,21 @@ namespace Potionapp_Mobile
 
             SetContentView(Resource.Layout.main_tabs);
 
+            var drawerLayout = FindViewById<DrawerLayout>(Resource.Id.drawer_layout)!;
+            var drawerList = FindViewById<ListView>(Resource.Id.drawer_list)!;
+
             var tabHost = FindViewById<TabHost>(Android.Resource.Id.TabHost)!;
             tabHost.Setup();
+
+            drawerList.Adapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1,
+                new[] { "Potions", "Recipes", "Ingredients" });
+            drawerList.ItemClick += (s, e) =>
+            {
+                tabHost.CurrentTab = e.Position;
+                drawerLayout.CloseDrawer(GravityCompat.Start);
+            };
+            FindViewById<Button>(Resource.Id.open_drawer_button)!.Click += (s, e) =>
+                drawerLayout.OpenDrawer(GravityCompat.Start);
 
             tabHost.AddTab(tabHost.NewTabSpec("potions").SetIndicator("Potions").SetContent(Resource.Id.tab_potions));
             tabHost.AddTab(tabHost.NewTabSpec("recipes").SetIndicator("Recipes").SetContent(Resource.Id.tab_recipes));
@@ -154,7 +169,7 @@ namespace Potionapp_Mobile
 
                 var addButton = FindViewById<Button>(Resource.Id.add_potion_button)!;
                 var confirmButton = FindViewById<Button>(Resource.Id.confirm_button)!;
-                var listView = FindViewById<ListView>(Resource.Id.selected_potions_list)!;
+                var listView = FindViewById<ListView>(Resource.Id.potion_queue_list)!;
 
                 selectedPotions = new List<string>();
                 listAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1, selectedPotions);

--- a/Resources/layout/activity_main.xml
+++ b/Resources/layout/activity_main.xml
@@ -21,6 +21,7 @@
             <EditText
                 android:id="@+id/animal_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -34,44 +35,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/animal_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/animal_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/animal_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/animal_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/animal_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/animal_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/animal_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/animal_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/animal_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/animal_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -87,6 +88,7 @@
             <EditText
                 android:id="@+id/berry_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -100,44 +102,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/berry_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/berry_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/berry_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/berry_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/berry_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/berry_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/berry_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/berry_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/berry_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/berry_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -153,6 +155,7 @@
             <EditText
                 android:id="@+id/fungi_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -166,44 +169,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/fungi_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/fungi_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/fungi_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/fungi_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/fungi_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/fungi_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/fungi_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/fungi_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/fungi_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/fungi_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -219,6 +222,7 @@
             <EditText
                 android:id="@+id/herb_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -232,44 +236,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/herb_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/herb_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/herb_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/herb_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/herb_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/herb_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/herb_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/herb_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/herb_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/herb_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -285,6 +289,7 @@
             <EditText
                 android:id="@+id/magic_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -298,44 +303,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/magic_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/magic_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/magic_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/magic_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/magic_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/magic_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/magic_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/magic_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/magic_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/magic_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -351,6 +356,7 @@
             <EditText
                 android:id="@+id/mineral_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -364,44 +370,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/mineral_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/mineral_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/mineral_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/mineral_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/mineral_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/mineral_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/mineral_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/mineral_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/mineral_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/mineral_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -417,6 +423,7 @@
             <EditText
                 android:id="@+id/root_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -430,44 +437,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/root_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/root_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/root_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/root_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/root_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/root_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/root_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/root_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/root_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/root_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -483,6 +490,7 @@
             <EditText
                 android:id="@+id/solution_amount"
                 android:inputType="number"
+                android:gravity="center"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content" />
             <TextView
@@ -496,44 +504,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/solution_minus1"
-                android:text="-1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/solution_plus1"
-                android:text="+1"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/solution_minus5"
-                android:text="-5"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/solution_plus5"
-                android:text="+5"
-                android:layout_width="50dp"
+                android:id="@+id/solution_minus100"
+                android:text="-100"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_minus10"
                 android:text="-10"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/solution_minus5"
+                android:text="-5"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/solution_minus1"
+                android:text="-1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/solution_plus1"
+                android:text="+1"
+                android:layout_width="45dp"
+                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/solution_plus5"
+                android:text="+5"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_plus10"
                 android:text="+10"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content" />
-            <Button
-                android:id="@+id/solution_minus100"
-                android:text="-100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_plus100"
                 android:text="+100"
-                android:layout_width="50dp"
+                android:layout_width="45dp"
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
@@ -548,9 +556,9 @@
             android:layout_height="wrap_content"
             android:text="Add Potion" />
 
-        <!-- Selected potions list -->
+        <!-- Potions queue list -->
         <ListView
-            android:id="@+id/selected_potions_list"
+            android:id="@+id/potion_queue_list"
             android:layout_width="match_parent"
             android:layout_height="200dp" />
 

--- a/Resources/layout/main_tabs.xml
+++ b/Resources/layout/main_tabs.xml
@@ -1,32 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TabHost xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/tabhost"
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <LinearLayout
-        android:orientation="vertical"
+
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <TabWidget
-            android:id="@android:id/tabs"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-        <FrameLayout
-            android:id="@android:id/tabcontent"
+
+        <TabHost
+            android:id="@android:id/tabhost"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
             <LinearLayout
-                android:id="@+id/tab_potions"
+                android:orientation="vertical"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-            <LinearLayout
-                android:id="@+id/tab_recipes"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-            <LinearLayout
-                android:id="@+id/tab_ingredients"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </FrameLayout>
-    </LinearLayout>
-</TabHost>
+                android:layout_height="match_parent">
+                <TabWidget
+                    android:id="@android:id/tabs"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+                <FrameLayout
+                    android:id="@android:id/tabcontent"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+                    <LinearLayout
+                        android:id="@+id/tab_potions"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent" />
+                    <LinearLayout
+                        android:id="@+id/tab_recipes"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent" />
+                    <LinearLayout
+                        android:id="@+id/tab_ingredients"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent" />
+                </FrameLayout>
+            </LinearLayout>
+        </TabHost>
+
+        <Button
+            android:id="@+id/open_drawer_button"
+            android:text="&#x22EE;"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentBottom="true" />
+
+    </RelativeLayout>
+
+    <ListView
+        android:id="@+id/drawer_list"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:choiceMode="singleChoice"
+        android:background="#ffffff" />
+</androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
## Summary
- add drawer layout and menu button to open sidebar
- center ingredient counts and shrink +/- buttons
- reorder adjust buttons to show negative first
- show queued potions list under Add Potion button

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e225929c832988437327ee3712e3