### PR TITLE
Fix tab labels and adjust ingredient controls

### DIFF
--- a/MainActivity.cs
+++ b/MainActivity.cs
@@ -84,7 +84,7 @@ namespace Potionapp_Mobile
             tabHost.Setup();
 
             drawerList.Adapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleListItem1,
-                new[] { "Potions", "Recipes", "Ingredients" });
+                new[] { "Brewing", "Ingredients", "Recipes" });
             drawerList.ItemClick += (s, e) =>
             {
                 tabHost.CurrentTab = e.Position;
@@ -93,9 +93,9 @@ namespace Potionapp_Mobile
             FindViewById<Button>(Resource.Id.open_drawer_button)!.Click += (s, e) =>
                 drawerLayout.OpenDrawer(GravityCompat.Start);
 
-            tabHost.AddTab(tabHost.NewTabSpec("potions").SetIndicator("Potions").SetContent(Resource.Id.tab_potions));
-            tabHost.AddTab(tabHost.NewTabSpec("recipes").SetIndicator("Recipes").SetContent(Resource.Id.tab_recipes));
+            tabHost.AddTab(tabHost.NewTabSpec("brewing").SetIndicator("Brewing").SetContent(Resource.Id.tab_potions));
             tabHost.AddTab(tabHost.NewTabSpec("ingredients").SetIndicator("Ingredients").SetContent(Resource.Id.tab_ingredients));
+            tabHost.AddTab(tabHost.NewTabSpec("recipes").SetIndicator("Recipes").SetContent(Resource.Id.tab_recipes));
 
             LayoutInflater.Inflate(
                 Resource.Layout.activity_main,
@@ -122,7 +122,7 @@ namespace Potionapp_Mobile
                 { "solution", FindViewById<EditText>(Resource.Id.solution_amount)! }
             };
 
-            var increments = new[] { 1, 5, 10, 100 };
+            var increments = new[] { 1, 5, 10 };
             foreach (var name in ingredientFields.Keys)
             {
                 foreach (var inc in increments)

--- a/Resources/layout/activity_main.xml
+++ b/Resources/layout/activity_main.xml
@@ -22,11 +22,13 @@
                 android:id="@+id/animal_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/animal_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -35,45 +37,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/animal_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/animal_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/animal_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -89,11 +83,13 @@
                 android:id="@+id/berry_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/berry_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -102,45 +98,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/berry_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/berry_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/berry_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -156,11 +144,13 @@
                 android:id="@+id/fungi_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/fungi_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -169,45 +159,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/fungi_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/fungi_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/fungi_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -223,11 +205,13 @@
                 android:id="@+id/herb_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/herb_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -236,45 +220,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/herb_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/herb_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/herb_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -290,11 +266,13 @@
                 android:id="@+id/magic_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/magic_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -303,45 +281,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/magic_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/magic_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/magic_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -357,11 +327,13 @@
                 android:id="@+id/mineral_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/mineral_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -370,45 +342,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/mineral_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/mineral_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/mineral_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -424,11 +388,13 @@
                 android:id="@+id/root_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/root_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -437,45 +403,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/root_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/root_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/root_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
@@ -491,11 +449,13 @@
                 android:id="@+id/solution_amount"
                 android:inputType="number"
                 android:gravity="center"
-                android:layout_width="80dp"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/solution_needed"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:text="0 (0)" />
         </LinearLayout>
@@ -504,45 +464,37 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <Button
-                android:id="@+id/solution_minus100"
-                android:text="-100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_minus10"
                 android:text="-10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_minus5"
                 android:text="-5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_minus1"
                 android:text="-1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_plus1"
                 android:text="+1"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_plus5"
                 android:text="+5"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
                 android:id="@+id/solution_plus10"
                 android:text="+10"
-                android:layout_width="45dp"
+                android:layout_width="54dp"
                 android:layout_height="wrap_content" />
             <Button
-                android:id="@+id/solution_plus100"
-                android:text="+100"
-                android:layout_width="45dp"
-                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <!-- Potion selector and add button -->


### PR DESCRIPTION
## Summary
- rename main navigation to Brewing/Ingredients/Recipes
- remove large increment buttons and widen remaining ones
- center ingredient counters
- adjust increment setup in code

## Testing
- `dotnet build "Potionapp Mobile.sln"` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845e72f312083299d852c65fa3da907